### PR TITLE
flatpak: clean up sassc and libsass

### DIFF
--- a/build-aux/flatpak/com.github.replaydev.Replay.json
+++ b/build-aux/flatpak/com.github.replaydev.Replay.json
@@ -27,6 +27,7 @@
   "modules": [
     {
       "name": "libsass",
+      "cleanup": ["*"],
       "config-opts": [
         "--disable-tests",
         "--disable-static",
@@ -48,6 +49,7 @@
     },
     {
       "name": "sassc",
+      "cleanup": ["*"],
       "sources": [
         {
           "type": "git",


### PR DESCRIPTION
They're not runtime dependencies, they're only for building libadwaita.